### PR TITLE
Retrieve Temporary authorization token

### DIFF
--- a/pages/register/register.vue
+++ b/pages/register/register.vue
@@ -17,7 +17,14 @@
 			}
 		},
 		methods: {
-			
+			register:function(){
+				uni.login({
+					provider:"weixin",
+					success:function(resp){
+						console.log(resp.code)
+					}
+				})
+			}
 		}
 	}
 </script>


### PR DESCRIPTION
Retrieve token from **Weixin** using uni.login()
The token will return weChat user info: Nickname & Photo
openID will be retrieved from token in server(java)